### PR TITLE
8 get articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -190,6 +190,7 @@ describe("GET /api/articles", () => {
       .get(`/api/articles`)
       .expect(200)
       .then(({ body }) => {
+        expect(body.articles).toHaveLength(12);
         body.articles.forEach((article) => {
           expect(article).toEqual(
             expect.objectContaining({

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -218,4 +218,21 @@ describe("GET /api/articles", () => {
         });
       });
   });
+
+  test("Status 200: Kev's bonus test to check the first object against values from the test data", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles[0]).toEqual({
+          article_id: 3,
+          title: "Eight pug gifs that remind me of mitch",
+          topic: "mitch",
+          author: "sam",
+          created_at: "2020-11-03T09:12:00.000Z",
+          votes: 0,
+          comment_count: 2,
+        });
+      });
+  });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -2,6 +2,7 @@ const request = require("supertest");
 const app = require("../app");
 const db = require("../db/connection");
 const seed = require("../db/seeds/seed");
+require("jest-sorted");
 
 const testData = require("../db/data/test-data");
 
@@ -201,6 +202,18 @@ describe("GET /api/articles", () => {
               comment_count: expect.any(Number),
             })
           );
+        });
+      });
+  });
+
+  test("Status 200: returns articles ordered by date, in descending order", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toBeSorted({
+          key: "created_at",
+          descending: true,
         });
       });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -60,6 +60,7 @@ describe("GET /api/articles/:article_id", () => {
         );
       });
   });
+
   test("Status 200: returns an individual article with comment count", () => {
     return request(app)
       .get(`/api/articles/1`)
@@ -178,6 +179,29 @@ describe("GET /api/users", () => {
       .then(({ body }) => {
         expect(body.users).toHaveLength(4);
         expect(body.users.every((user) => user.username)).toBe(true);
+      });
+  });
+});
+
+describe("GET /api/articles", () => {
+  test("Status 200: returns a list of articles", () => {
+    return request(app)
+      .get(`/api/articles`)
+      .expect(200)
+      .then(({ body }) => {
+        body.articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              article_id: expect.any(Number),
+              title: expect.any(String),
+              topic: expect.any(String),
+              author: expect.any(String),
+              created_at: expect.any(String), // ignore GMT/BST conversion
+              votes: expect.any(Number),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const { getTopics } = require("./controllers/topics.controller");
 const {
   getArticle,
+  getArticles,
   patchArticle,
 } = require("./controllers/articles.controller");
 const { getUsers } = require("./controllers/users.controller");
@@ -11,6 +12,7 @@ app.use(express.json());
 
 app.get("/api/topics", getTopics);
 
+app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id", getArticle);
 app.patch("/api/articles/:article_id", patchArticle);
 

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,9 +1,23 @@
-const { fetchArticle, updateArticle } = require("../models/articles.model");
+const {
+  fetchArticles,
+  fetchArticle,
+  updateArticle,
+} = require("../models/articles.model");
 
 exports.getArticle = (req, res, next) => {
   fetchArticle(req.params.article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.getArticles = (req, res, next) => {
+  fetchArticles()
+    .then((articles) => {
+      res.status(200).send({ articles });
     })
     .catch((err) => {
       next(err);

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -28,6 +28,28 @@ exports.fetchArticle = (article_id) => {
   });
 };
 
+exports.fetchArticles = () => {
+  const queryStr = `
+  SELECT
+    users.name AS author,
+    a.title,
+    a.article_id,
+    a.topic,
+    a.created_at,
+    a.votes,
+    ( SELECT CAST (COUNT(*) AS INTEGER)
+      FROM comments
+      WHERE comments.article_id = a.article_id
+    ) AS comment_count
+  FROM articles AS a
+  JOIN users ON a.author = users.username;
+`;
+
+  return db.query(queryStr).then((results) => {
+    return results.rows;
+  });
+};
+
 exports.updateArticle = (article_id, body) => {
   if (body.inc_votes) {
     const queryStr = `

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -42,7 +42,8 @@ exports.fetchArticles = () => {
       WHERE comments.article_id = a.article_id
     ) AS comment_count
   FROM articles AS a
-  JOIN users ON a.author = users.username;
+  JOIN users ON a.author = users.username
+  ORDER BY a.created_at DESC;
 `;
 
   return db.query(queryStr).then((results) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "husky": "^7.0.0",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.14",
         "pg-format": "^1.0.4",
         "supertest": "^6.2.3"
       }
@@ -3144,6 +3145,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7368,6 +7375,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^7.0.0",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.14",
     "pg-format": "^1.0.4",
     "supertest": "^6.2.3"
   },


### PR DESCRIPTION
Adds /api/articles endpoint that returns a list of articles, ordered by created_at, in descending order.

Tests: 
* 200: Array of articles has length and articles are the correct shape
* 200: Returns in correct order (using jest-sorted)

To be consistent with /api/topics this will return a 200 and empty array if there were no articles in the DB.