### PR TITLE
9 get article comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -257,4 +257,13 @@ describe("GET /api/articles/:article_id/comments", () => {
         });
       });
   });
+
+  test("Status 200: returns an empty array if there are no comments for the specified article", () => {
+    return request(app)
+      .get(`/api/articles/2/comments`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comments).toEqual([]);
+      });
+  });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -266,4 +266,22 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(body.comments).toEqual([]);
       });
   });
+
+  test("Status 400: should indicate bad request if article_id is invalid value not exist", () => {
+    return request(app)
+      .get("/api/articles/one/comments")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
+
+  test("Status 404: should indicate if an article_id is not found", () => {
+    return request(app)
+      .get("/api/articles/900000/comments")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Not found.");
+      });
+  });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -236,3 +236,25 @@ describe("GET /api/articles", () => {
       });
   });
 });
+
+describe("GET /api/articles/:article_id/comments", () => {
+  test("Status 200: returns a list of comments for the specified article", () => {
+    return request(app)
+      .get(`/api/articles/1/comments`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comments).toHaveLength(11);
+        body.comments.forEach((comment) => {
+          expect(comment).toEqual(
+            expect.objectContaining({
+              comment_id: expect.any(Number),
+              votes: expect.any(Number),
+              created_at: expect.any(String),
+              author: expect.any(String),
+              body: expect.any(String),
+            })
+          );
+        });
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@ const {
   patchArticle,
 } = require("./controllers/articles.controller");
 const { getUsers } = require("./controllers/users.controller");
+const { getCommentsByArticle } = require("./controllers/comments.controller");
+
 const app = express();
 
 app.use(express.json());
@@ -14,6 +16,8 @@ app.get("/api/topics", getTopics);
 
 app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id", getArticle);
+app.get("/api/articles/:article_id/comments", getCommentsByArticle);
+
 app.patch("/api/articles/:article_id", patchArticle);
 
 app.get("/api/users", getUsers);

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,0 +1,12 @@
+const { fetchArticle } = require("../models/articles.model");
+const { fetchCommentsByArticle } = require("../models/comments.model");
+
+exports.getCommentsByArticle = (req, res, next) => {
+  fetchCommentsByArticle(req.params.article_id)
+    .then((comments) => {
+      res.status(200).send({ comments });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -2,8 +2,10 @@ const { fetchArticle } = require("../models/articles.model");
 const { fetchCommentsByArticle } = require("../models/comments.model");
 
 exports.getCommentsByArticle = (req, res, next) => {
-  fetchCommentsByArticle(req.params.article_id)
-    .then((comments) => {
+  const { article_id } = req.params;
+
+  Promise.all([fetchArticle(article_id), fetchCommentsByArticle(article_id)])
+    .then(([_, comments]) => {
       res.status(200).send({ comments });
     })
     .catch((err) => {

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,0 +1,21 @@
+const db = require("../db/connection");
+
+exports.fetchCommentsByArticle = (article_id) => {
+  const queryStr = `
+    SELECT 
+      users.name AS author,
+      c.comment_id, 
+      c.votes, c.created_at, 
+      c.body 
+    FROM comments AS c 
+    JOIN users ON c.author = users.username 
+    WHERE article_id = $1;
+  `;
+
+  const queryVals = [article_id];
+
+  return db.query(queryStr, queryVals).then((results) => {
+    console.log(results.rows);
+    return results.rows;
+  });
+};

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -15,7 +15,6 @@ exports.fetchCommentsByArticle = (article_id) => {
   const queryVals = [article_id];
 
   return db.query(queryStr, queryVals).then((results) => {
-    console.log(results.rows);
     return results.rows;
   });
 };


### PR DESCRIPTION
Adds /api/articles/:article_id/comments endpoint to retrieve a list of comments for a given article.

Tests: 
* Returns the correct number of comments and shape of comments match for a valid article
* Returns an empty array when an article has no comments
* Returns 400 is the article_id is invalid 
* Returns 404 if the article_id does not exist in the DB