### PR TITLE
11 queries

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -342,16 +342,16 @@ describe("POST /api/articles/:article_id/comments", () => {
       });
   });
 
-  test("Status 422: returns unprocessable entity when given an unknown user", () => {
+  test("Status 404: returns unprocessable entity when given an unknown user", () => {
     return request(app)
       .post("/api/articles/1/comments")
       .send({
         username: "andy",
         body: "a test comment",
       })
-      .expect(422)
+      .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe("Unprocessable entity.");
+        expect(body.msg).toBe("Not found.");
       });
   });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -235,39 +235,46 @@ describe("GET /api/articles", () => {
         });
       });
   });
-  describe("Queries", () => {
-    test("Status 200: returns articles sorted by the given query", () => {
-      return request(app)
-        .get("/api/articles?sort_by=comment_count")
-        .expect(200)
-        .then(({ body }) => {
-          expect(body.articles).toBeSorted({
-            key: "comment_count",
-            descending: true,
-          });
+  test("Status 200: returns articles sorted by the given query", () => {
+    return request(app)
+      .get("/api/articles?sort_by=comment_count")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toBeSorted({
+          key: "comment_count",
+          descending: true,
         });
-    });
+      });
+  });
 
-    test("Status 400: only sorts on permitted columns", () => {
-      return request(app)
-        .get("/api/articles?sort_by=banana")
-        .expect(400)
-        .then(({ body }) => {
-          expect(body.msg).toBe("Bad request.");
-        });
-    });
+  test("Status 400: only sorts on permitted columns", () => {
+    return request(app)
+      .get("/api/articles?sort_by=banana")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
 
-    test("Status 200: returns articles in the specified order", () => {
-      return request(app)
-        .get("/api/articles?order=asc")
-        .expect(200)
-        .then(({ body }) => {
-          expect(body.articles).toBeSorted({
-            key: "created_at",
-            descending: false,
-          });
+  test("Status 200: returns articles in the specified order", () => {
+    return request(app)
+      .get("/api/articles?order=asc")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toBeSorted({
+          key: "created_at",
+          descending: false,
         });
-    });
+      });
+  });
+
+  test("Status: 400: only orders on permitted values", () => {
+    return request(app)
+      .get("/api/articles?order=banana")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -276,6 +276,20 @@ describe("GET /api/articles", () => {
         expect(body.msg).toBe("Bad request.");
       });
   });
+
+  test("Status 200: returns articles on a given topic", () => {
+    return request(app)
+      .get("/api/articles?topic=mitch")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(11);
+        expect(
+          body.articles.every((article) => article.topic === "mitch")
+        ).toBe(true);
+      });
+  });
+
+  // test topic with no articles is empty
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -235,6 +235,19 @@ describe("GET /api/articles", () => {
         });
       });
   });
+  describe.only("Queries", () => {
+    test("Status 200: returns articles sorted by the given query", () => {
+      return request(app)
+        .get("/api/articles?sort_by=comment_count")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.articles).toBeSorted({
+            key: "comment_count",
+            descending: true,
+          });
+        });
+    });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -235,6 +235,7 @@ describe("GET /api/articles", () => {
         });
       });
   });
+
   test("Status 200: returns articles sorted by the given query", () => {
     return request(app)
       .get("/api/articles?sort_by=comment_count")
@@ -304,6 +305,52 @@ describe("GET /api/articles", () => {
       .expect(404)
       .then(({ body }) => {
         expect(body.msg).toBe("Not found.");
+      });
+  });
+
+  test("Status 200: returns correct results for multiple queries", () => {
+    return request(app)
+      .get("/api/articles?sort_by=votes&order=asc&topic=mitch")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(11);
+        expect(body.articles).toBeSorted({ key: "votes", descending: false });
+      });
+  });
+
+  test("Status 400: bad request if using a key that isn't sort_by", () => {
+    return request(app)
+      .get("/api/articles?sort=comment_count")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
+
+  test("Status 400: bad request if using incorrect key to order", () => {
+    return request(app)
+      .get("/api/articles?order_by=asc")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
+
+  test("Status 400: bad request if using an incorrect key for topics", () => {
+    return request(app)
+      .get("/api/articles?get_topic=mitch")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
+
+  test("Status 400: bad request if using a key that isn't permitted", () => {
+    return request(app)
+      .get("/api/articles?article_id=1")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -235,7 +235,7 @@ describe("GET /api/articles", () => {
         });
       });
   });
-  describe.only("Queries", () => {
+  describe("Queries", () => {
     test("Status 200: returns articles sorted by the given query", () => {
       return request(app)
         .get("/api/articles?sort_by=comment_count")
@@ -244,6 +244,27 @@ describe("GET /api/articles", () => {
           expect(body.articles).toBeSorted({
             key: "comment_count",
             descending: true,
+          });
+        });
+    });
+
+    test("Status 400: only sorts on permitted columns", () => {
+      return request(app)
+        .get("/api/articles?sort_by=banana")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Bad request.");
+        });
+    });
+
+    test("Status 200: returns articles in the specified order", () => {
+      return request(app)
+        .get("/api/articles?order=asc")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.articles).toBeSorted({
+            key: "created_at",
+            descending: false,
           });
         });
     });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -289,7 +289,23 @@ describe("GET /api/articles", () => {
       });
   });
 
-  // test topic with no articles is empty
+  test("Status 200: returns empty array when given topic that exists, but has no articles", () => {
+    return request(app)
+      .get("/api/articles?topic=paper")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(0);
+      });
+  });
+
+  test("Status 404: specified topic does not exist in the db", () => {
+    return request(app)
+      .get("/api/articles?topic=banana")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Not found.");
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ app.use((err, req, res, next) => {
   if (err.code === "22P02") {
     res.status(400).send({ msg: "Bad request." });
   } else if (err.code === "23503") {
-    res.status(422).send({ msg: "Unprocessable entity." });
+    res.status(404).send({ msg: "Not found." });
   } else {
     next(err);
   }

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -15,8 +15,8 @@ exports.getArticle = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  const { sort_by, order } = req.query;
-  fetchArticles(sort_by, order)
+  const { sort_by, order, topic } = req.query;
+  fetchArticles(sort_by, order, topic)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -15,7 +15,8 @@ exports.getArticle = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  fetchArticles()
+  const { sort_by } = req.query;
+  fetchArticles(sort_by)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -17,6 +17,15 @@ exports.getArticle = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
+  const permittedQueries = ["sort_by", "order", "topic"];
+
+  // throws error on invalid query (?sort=..., or ?topics)
+  if (
+    !Object.keys(req.query).every((query) => permittedQueries.includes(query))
+  ) {
+    throw { status: 400, msg: "Bad request." };
+  }
+
   const { sort_by, order, topic } = req.query;
   Promise.all([fetchTopics(), fetchArticles(sort_by, order, topic)])
     .then(([topics, articles]) => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -15,8 +15,8 @@ exports.getArticle = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  const { sort_by } = req.query;
-  fetchArticles(sort_by)
+  const { sort_by, order } = req.query;
+  fetchArticles(sort_by, order)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -28,8 +28,8 @@ exports.fetchArticle = (article_id) => {
   });
 };
 
-exports.fetchArticles = () => {
-  const queryStr = `
+exports.fetchArticles = (sort_by = "created_at") => {
+  let queryStr = `
   SELECT
     users.name AS author,
     a.title,
@@ -42,11 +42,12 @@ exports.fetchArticles = () => {
       WHERE comments.article_id = a.article_id
     ) AS comment_count
   FROM articles AS a
-  JOIN users ON a.author = users.username
-  ORDER BY a.created_at DESC;
-`;
+  JOIN users ON a.author = users.username`;
+
+  queryStr += ` ORDER BY ${sort_by} DESC`;
 
   return db.query(queryStr).then((results) => {
+    console.log(results.rows);
     return results.rows;
   });
 };

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -28,7 +28,18 @@ exports.fetchArticle = (article_id) => {
   });
 };
 
-exports.fetchArticles = (sort_by = "created_at") => {
+exports.fetchArticles = (sort_by = "created_at", order = "desc") => {
+  const permittedSortOptions = [
+    "created_at",
+    "comment_count",
+    "votes",
+    "article_id",
+  ];
+
+  if (!permittedSortOptions.includes(sort_by)) {
+    return Promise.reject({ status: 400, msg: "Bad request." });
+  }
+
   let queryStr = `
   SELECT
     users.name AS author,
@@ -44,7 +55,9 @@ exports.fetchArticles = (sort_by = "created_at") => {
   FROM articles AS a
   JOIN users ON a.author = users.username`;
 
-  queryStr += ` ORDER BY ${sort_by} DESC`;
+  queryStr += ` ORDER BY ${sort_by} ${order}`;
+
+  console.log(queryStr);
 
   return db.query(queryStr).then((results) => {
     console.log(results.rows);

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -36,7 +36,12 @@ exports.fetchArticles = (sort_by = "created_at", order = "desc") => {
     "article_id",
   ];
 
-  if (!permittedSortOptions.includes(sort_by)) {
+  const permittedOrderOptions = ["asc", "desc"];
+
+  if (
+    !permittedSortOptions.includes(sort_by) ||
+    !permittedOrderOptions.includes(order)
+  ) {
     return Promise.reject({ status: 400, msg: "Bad request." });
   }
 

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -28,7 +28,7 @@ exports.fetchArticle = (article_id) => {
   });
 };
 
-exports.fetchArticles = (sort_by = "created_at", order = "desc") => {
+exports.fetchArticles = (sort_by = "created_at", order = "desc", topic) => {
   const permittedSortOptions = [
     "created_at",
     "comment_count",
@@ -37,6 +37,8 @@ exports.fetchArticles = (sort_by = "created_at", order = "desc") => {
   ];
 
   const permittedOrderOptions = ["asc", "desc"];
+
+  const queryVals = [];
 
   if (
     !permittedSortOptions.includes(sort_by) ||
@@ -57,11 +59,19 @@ exports.fetchArticles = (sort_by = "created_at", order = "desc") => {
   FROM articles AS a
     LEFT JOIN users ON users.username = a.author
     LEFT JOIN comments ON comments.article_id = a.article_id
-  GROUP BY a.article_id, a.title, users.username`;
+  `;
 
-  queryStr += ` ORDER BY ${sort_by} ${order}`;
+  if (topic) {
+    queryStr += ` WHERE a.topic = $1`;
+    queryVals.push(topic);
+  }
 
-  return db.query(queryStr).then((results) => {
+  queryStr += `
+    GROUP BY a.article_id, a.title, users.username
+    ORDER BY ${sort_by} ${order}
+    `;
+
+  return db.query(queryStr, queryVals).then((results) => {
     return results.rows;
   });
 };


### PR DESCRIPTION
This adds queries for sorting, order and to filter by topic.

Tests:
* `sort_by` is limited to four columns (hard coded) and defaults to `created_at` if not present
* `order` is limited to `asc` or `desc` (currently case sensitive) and defaults to `desc` if not present
* `topic` must be a topic that exists in the topics table (confirmed in the controller), will return 200 and empty array if the topic is present in that table but there are not currently any articles with that topic  

PS. there was a _tiny_ little bit of refactoring to remove an inaccurate error code in a previous test and to tidy up the SQL queries based on this morning's Q&A. 