### PR TITLE
20 pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project requires: Node.js (v17.x) and PostgreSQL (v13.6 or above).
 To setup and test this project:
 
 1. Clone the respository and `cd` into the directory
-2. Run `npm install --production=false` to install the project and developer dependencies
+2. Run `npm install` to install the project and any dependencies
 3. From the root of the project directory, run the following to set up environment variables for the test and dev database: :
 
    ```

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -399,6 +399,24 @@ describe("GET /api/articles", () => {
         expect(body.articles).toHaveLength(10);
       });
   });
+
+  test("Status 200: returns specified number of articles", () => {
+    return request(app)
+      .get("/api/articles?limit=5")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(5);
+      });
+  });
+
+  test("Status 200: returns specified number of articles for a specified topic", () => {
+    return request(app)
+      .get("/api/articles?limit=5&topic=mitch")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(5);
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -440,7 +440,6 @@ describe("GET /api/articles", () => {
       .get("/api/articles?sort_by=article_id&order=asc&limit=5&p=1")
       .expect(200)
       .then(({ body }) => {
-        console.log(body.articles);
         expect(body.articles).toHaveLength(5);
         expect(body.articles[0].article_id).toBe(6);
       });
@@ -451,6 +450,14 @@ describe("GET /api/articles", () => {
       .expect(400)
       .then(({ body }) => {
         expect(body.msg).toBe("Bad request.");
+      });
+  });
+  test("Status 404: returns not found when accessing a page that does not yet exist", () => {
+    return request(app)
+      .get("/api/articles?p=900000")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Not found.");
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -435,6 +435,16 @@ describe("GET /api/articles", () => {
         expect(body.articles).toHaveLength(2);
       });
   });
+  test("Status 400: offset is calculated when given a custom limit", () => {
+    return request(app)
+      .get("/api/articles?sort_by=article_id&order=asc&limit=5&p=1")
+      .expect(200)
+      .then(({ body }) => {
+        console.log(body.articles);
+        expect(body.articles).toHaveLength(5);
+        expect(body.articles[0].article_id).toBe(6);
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -227,7 +227,7 @@ describe("GET /api/articles", () => {
       .get(`/api/articles`)
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles).toHaveLength(12);
+        expect(body.articles).toHaveLength(10);
         body.articles.forEach((article) => {
           expect(article).toEqual(
             expect.objectContaining({
@@ -320,7 +320,7 @@ describe("GET /api/articles", () => {
       .get("/api/articles?topic=mitch")
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles).toHaveLength(11);
+        expect(body.articles).toHaveLength(10);
         expect(
           body.articles.every((article) => article.topic === "mitch")
         ).toBe(true);
@@ -350,7 +350,7 @@ describe("GET /api/articles", () => {
       .get("/api/articles?sort_by=votes&order=asc&topic=mitch")
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles).toHaveLength(11);
+        expect(body.articles).toHaveLength(10);
         expect(body.articles).toBeSorted({ key: "votes", descending: false });
       });
   });
@@ -388,6 +388,15 @@ describe("GET /api/articles", () => {
       .expect(400)
       .then(({ body }) => {
         expect(body.msg).toBe("Bad request.");
+      });
+  });
+
+  test("Status 200: returns 10 comments by default", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(10);
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -391,7 +391,7 @@ describe("GET /api/articles", () => {
       });
   });
 
-  test("Status 200: returns 10 comments by default", () => {
+  test("Status 200: returns 10 articles by default", () => {
     return request(app)
       .get("/api/articles")
       .expect(200)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -435,7 +435,7 @@ describe("GET /api/articles", () => {
         expect(body.articles).toHaveLength(2);
       });
   });
-  test("Status 400: offset is calculated when given a custom limit", () => {
+  test("Status 200: offset is calculated when given a custom limit", () => {
     return request(app)
       .get("/api/articles?sort_by=article_id&order=asc&limit=5&p=1")
       .expect(200)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -426,6 +426,15 @@ describe("GET /api/articles", () => {
         expect(body.msg).toBe("Bad request.");
       });
   });
+
+  test("Status 200: can specify a page and return articles starting from that value", () => {
+    return request(app)
+      .get("/api/articles?p=1")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(2);
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -417,6 +417,15 @@ describe("GET /api/articles", () => {
         expect(body.articles).toHaveLength(5);
       });
   });
+
+  test("Status 400: returns bad request when using an incorrect value for limit", () => {
+    return request(app)
+      .get("/api/articles?limit=five")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -227,7 +227,7 @@ describe("GET /api/articles", () => {
       .get(`/api/articles`)
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles).toHaveLength(10);
+        expect(body.articles).toBeTruthy();
         body.articles.forEach((article) => {
           expect(article).toEqual(
             expect.objectContaining({
@@ -256,7 +256,7 @@ describe("GET /api/articles", () => {
       });
   });
 
-  test("Status 200: Kev's bonus test to check the first object against values from the test data", () => {
+  test("Status 200: check the first object against values from the test data", () => {
     return request(app)
       .get("/api/articles")
       .expect(200)
@@ -320,7 +320,7 @@ describe("GET /api/articles", () => {
       .get("/api/articles?topic=mitch")
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles).toHaveLength(10);
+        expect(body.articles).toBeTruthy();
         expect(
           body.articles.every((article) => article.topic === "mitch")
         ).toBe(true);
@@ -350,7 +350,7 @@ describe("GET /api/articles", () => {
       .get("/api/articles?sort_by=votes&order=asc&topic=mitch")
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles).toHaveLength(10);
+        expect(body.articles.length).toBeTruthy();
         expect(body.articles).toBeSorted({ key: "votes", descending: false });
       });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -445,6 +445,14 @@ describe("GET /api/articles", () => {
         expect(body.articles[0].article_id).toBe(6);
       });
   });
+  test("Status 400: returns bad request when using an incorrect value for page", () => {
+    return request(app)
+      .get("/api/articles?p=five")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -469,6 +469,24 @@ describe("GET /api/articles", () => {
         expect(body.total_count).toBe(12);
       });
   });
+
+  test("Status 200: returns the total article count alongside the array of articles with topic filters applied", () => {
+    return request(app)
+      .get("/api/articles?topic=mitch")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.total_count).toBe(11);
+      });
+  });
+
+  test("Status 200: returns the total article count alongside the array of articles with topic filters applied when there are no articles for a topic", () => {
+    return request(app)
+      .get("/api/articles?topic=paper")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.total_count).toBe(0);
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -460,6 +460,15 @@ describe("GET /api/articles", () => {
         expect(body.msg).toBe("Not found.");
       });
   });
+
+  test("Status 200: returns the total article count alongside the array of articles", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.total_count).toBe(12);
+      });
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -34,8 +34,8 @@ exports.getArticles = (req, res, next) => {
     fetchArticles(sort_by, order, limit, p, topic),
     countArticles(),
   ])
-    .then(([topics, articles, { count }]) => {
-      if (p > count) {
+    .then(([topics, articles, { total_count }]) => {
+      if (p > total_count) {
         return Promise.reject({ status: 404, msg: "Not found." });
       }
 
@@ -43,7 +43,7 @@ exports.getArticles = (req, res, next) => {
         return Promise.reject({ status: 404, msg: "Not found." });
       }
 
-      res.status(200).send({ articles });
+      res.status(200).send({ articles, total_count });
     })
     .catch((err) => {
       next(err);

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -18,7 +18,7 @@ exports.getArticle = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  const permittedQueries = ["sort_by", "order", "topic"];
+  const permittedQueries = ["sort_by", "order", "topic", "limit"];
 
   // throws error on invalid query (?sort=..., or ?topics)
   if (
@@ -27,8 +27,8 @@ exports.getArticles = (req, res, next) => {
     throw { status: 400, msg: "Bad request." };
   }
 
-  const { sort_by, order, topic } = req.query;
-  Promise.all([fetchTopics(), fetchArticles(sort_by, order, topic)])
+  const { sort_by, order, topic, limit } = req.query;
+  Promise.all([fetchTopics(), fetchArticles(sort_by, order, limit, topic)])
     .then(([topics, articles]) => {
       if (topic) {
         if (topics.find((ele) => ele.slug === topic)) {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -18,7 +18,7 @@ exports.getArticle = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  const permittedQueries = ["sort_by", "order", "topic", "limit"];
+  const permittedQueries = ["sort_by", "order", "topic", "limit", "p"];
 
   // throws error on invalid query (?sort=..., or ?topics)
   if (
@@ -27,8 +27,8 @@ exports.getArticles = (req, res, next) => {
     throw { status: 400, msg: "Bad request." };
   }
 
-  const { sort_by, order, topic, limit } = req.query;
-  Promise.all([fetchTopics(), fetchArticles(sort_by, order, limit, topic)])
+  const { sort_by, order, topic, limit, p } = req.query;
+  Promise.all([fetchTopics(), fetchArticles(sort_by, order, limit, p, topic)])
     .then(([topics, articles]) => {
       if (topic) {
         if (topics.find((ele) => ele.slug === topic)) {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -32,7 +32,7 @@ exports.getArticles = (req, res, next) => {
   Promise.all([
     fetchTopics(),
     fetchArticles(sort_by, order, limit, p, topic),
-    countArticles(),
+    countArticles(topic),
   ])
     .then(([topics, articles, { total_count }]) => {
       if (p > total_count) {

--- a/endpoints.json
+++ b/endpoints.json
@@ -11,7 +11,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["topic", "sort_by", "order"],
+    "queries": ["topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
       "articles": [
         {
@@ -34,7 +34,8 @@
           "votes": 0,
           "comment_count": 0
         }
-      ]
+      ],
+      "total_count": 2
     }
   },
   "GET /api/articles/:article_id": {

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -32,6 +32,7 @@ exports.fetchArticles = (
   sort_by = "created_at",
   order = "desc",
   limit = 10,
+  p = 0,
   topic
 ) => {
   const permittedSortOptions = [
@@ -43,7 +44,7 @@ exports.fetchArticles = (
 
   const permittedOrderOptions = ["asc", "desc"];
 
-  const queryVals = [];
+  const queryVals = [limit, p * limit];
 
   if (
     !permittedSortOptions.includes(sort_by) ||
@@ -67,7 +68,7 @@ exports.fetchArticles = (
   `;
 
   if (topic) {
-    queryStr += ` WHERE a.topic = $1`;
+    queryStr += ` WHERE a.topic = $3`;
     queryVals.push(topic);
   }
 
@@ -76,16 +77,9 @@ exports.fetchArticles = (
     ORDER BY ${sort_by} ${order}
     `;
 
-  if (topic) {
-    queryStr += `
-    LIMIT $2
-    `;
-  } else {
-    queryStr += `
-    LIMIT $1
-    `;
-  }
-  queryVals.push(limit);
+  queryStr += `
+  LIMIT $1 OFFSET $2
+  `;
 
   return db.query(queryStr, queryVals).then((results) => {
     return results.rows;

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -71,6 +71,10 @@ exports.fetchArticles = (sort_by = "created_at", order = "desc", topic) => {
     ORDER BY ${sort_by} ${order}
     `;
 
+  queryStr += `
+    LIMIT 10
+    `;
+
   return db.query(queryStr, queryVals).then((results) => {
     return results.rows;
   });

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,11 +1,19 @@
 const db = require("../db/connection");
 
-exports.countArticles = () => {
-  return db
-    .query(`SELECT COUNT(*)::INT AS total_count FROM articles;`)
-    .then((results) => {
-      return results.rows[0];
-    });
+exports.countArticles = (topic) => {
+  let queryStr = `SELECT COUNT (*)::INT AS total_count
+  FROM articles`;
+  const queryVals = [];
+
+  if (topic) {
+    queryStr += `
+    WHERE topic = $1`;
+    queryVals.push(topic);
+  }
+
+  return db.query(queryStr, queryVals).then((results) => {
+    return results.rows[0];
+  });
 };
 exports.fetchArticle = (article_id) => {
   const queryStr = `

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -28,7 +28,12 @@ exports.fetchArticle = (article_id) => {
   });
 };
 
-exports.fetchArticles = (sort_by = "created_at", order = "desc", topic) => {
+exports.fetchArticles = (
+  sort_by = "created_at",
+  order = "desc",
+  limit = 10,
+  topic
+) => {
   const permittedSortOptions = [
     "created_at",
     "comment_count",
@@ -71,9 +76,16 @@ exports.fetchArticles = (sort_by = "created_at", order = "desc", topic) => {
     ORDER BY ${sort_by} ${order}
     `;
 
-  queryStr += `
-    LIMIT 10
+  if (topic) {
+    queryStr += `
+    LIMIT $2
     `;
+  } else {
+    queryStr += `
+    LIMIT $1
+    `;
+  }
+  queryVals.push(limit);
 
   return db.query(queryStr, queryVals).then((results) => {
     return results.rows;

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,5 +1,10 @@
 const db = require("../db/connection");
 
+exports.countArticles = () => {
+  return db.query(`SELECT COUNT(*) FROM articles;`).then((results) => {
+    return results.rows[0];
+  });
+};
 exports.fetchArticle = (article_id) => {
   const queryStr = `
   SELECT
@@ -68,7 +73,8 @@ exports.fetchArticles = (
   `;
 
   if (topic) {
-    queryStr += ` WHERE a.topic = $3`;
+    queryStr += `WHERE a.topic = $3
+    `;
     queryVals.push(topic);
   }
 

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,9 +1,11 @@
 const db = require("../db/connection");
 
 exports.countArticles = () => {
-  return db.query(`SELECT COUNT(*) FROM articles;`).then((results) => {
-    return results.rows[0];
-  });
+  return db
+    .query(`SELECT COUNT(*)::INT AS total_count FROM articles;`)
+    .then((results) => {
+      return results.rows[0];
+    });
 };
 exports.fetchArticle = (article_id) => {
   const queryStr = `


### PR DESCRIPTION
Adds pagination to /api/articles, via `p` and `limit` queries and additional `total_count` property on the response. Previous tests were refactored to account for new default values

Tests: 
* 200 returns 10 articles by default
* 200 returns specified number of articles
* 200 returns number of articles when combined with a topic
* 400 incorrect value for limit
* 200 specify a page (indexed from 0) to start at
* 200 limit and page calculated correctly
* 400 incorrect value for page
* 404 page does not exist
* 200 returns total count of articles
* 200 returns total count of articles with topic filter
* 200 returns 0 when topic filter has no articles