### PR TITLE
21 paginate comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -495,7 +495,7 @@ describe("GET /api/articles/:article_id/comments", () => {
       .get(`/api/articles/1/comments`)
       .expect(200)
       .then(({ body }) => {
-        expect(body.comments).toHaveLength(11);
+        expect(body.comments.length).toBeTruthy();
         body.comments.forEach((comment) => {
           expect(comment).toEqual(
             expect.objectContaining({
@@ -534,6 +534,24 @@ describe("GET /api/articles/:article_id/comments", () => {
       .expect(404)
       .then(({ body }) => {
         expect(body.msg).toBe("Not found.");
+      });
+  });
+
+  test("Status 200: returns 10 comments by default", () => {
+    return request(app)
+      .get("/api/articles/1/comments")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comments.length).toBe(10);
+      });
+  });
+
+  test("Status 200: returns specified number of comments", () => {
+    return request(app)
+      .get("/api/articles/1/comments?limit=5")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comments.length).toBe(5);
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -554,6 +554,15 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(body.comments.length).toBe(5);
       });
   });
+
+  test("Status 400: returns bad request when given an incorrect value for limit", () => {
+    return request(app)
+      .get("/api/articles/1/comments?limit=five")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
 });
 
 describe("POST /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -563,6 +563,15 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(body.msg).toBe("Bad request.");
       });
   });
+
+  test("Status 200: specify a page to start at", () => {
+    return request(app)
+      .get("/api/articles/1/comments?p=1")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comments.length).toBe(1);
+      });
+  });
 });
 
 describe("POST /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -590,6 +590,15 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(body.msg).toBe("Bad request.");
       });
   });
+
+  test("Status 404: returns not found when p does not exist", () => {
+    return request(app)
+      .get("/api/articles/1/comments?p=90000")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Not found.");
+      });
+  });
 });
 
 describe("POST /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -581,6 +581,15 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(body.comments.length).toBe(1);
       });
   });
+
+  test("Status 400: returns bad request when p is given incorrect value", () => {
+    return request(app)
+      .get("/api/articles/1/comments?p=two")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request.");
+      });
+  });
 });
 
 describe("POST /api/articles/:article_id/comments", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -572,6 +572,15 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(body.comments.length).toBe(1);
       });
   });
+
+  test("Status 200: limit and page calculate correctly", () => {
+    return request(app)
+      .get("/api/articles/1/comments?limit=5&p=2")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comments.length).toBe(1);
+      });
+  });
 });
 
 describe("POST /api/articles/:article_id/comments", () => {

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -8,11 +8,11 @@ const {
 
 exports.getCommentsByArticle = (req, res, next) => {
   const { article_id } = req.params;
-  const { limit } = req.query;
+  const { limit, p } = req.query;
 
   Promise.all([
     fetchArticle(article_id),
-    fetchCommentsByArticle(article_id, limit),
+    fetchCommentsByArticle(article_id, limit, p),
   ])
     .then(([_, comments]) => {
       res.status(200).send({ comments });

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -3,6 +3,7 @@ const {
   fetchCommentsByArticle,
   insertComment,
   updateComment,
+  totalCommentsByArticle,
   removeComment,
 } = require("../models/comments.model");
 
@@ -13,9 +14,14 @@ exports.getCommentsByArticle = (req, res, next) => {
   Promise.all([
     fetchArticle(article_id),
     fetchCommentsByArticle(article_id, limit, p),
+    totalCommentsByArticle(article_id),
   ])
-    .then(([_, comments]) => {
-      res.status(200).send({ comments });
+    .then(([_, comments, { total_count }]) => {
+      if (p > total_count) {
+        return Promise.reject({ status: 404, msg: "Not found." });
+      } else {
+        res.status(200).send({ comments });
+      }
     })
     .catch((err) => {
       next(err);

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -8,8 +8,12 @@ const {
 
 exports.getCommentsByArticle = (req, res, next) => {
   const { article_id } = req.params;
+  const { limit } = req.query;
 
-  Promise.all([fetchArticle(article_id), fetchCommentsByArticle(article_id)])
+  Promise.all([
+    fetchArticle(article_id),
+    fetchCommentsByArticle(article_id, limit),
+  ])
     .then(([_, comments]) => {
       res.status(200).send({ comments });
     })

--- a/endpoints.json
+++ b/endpoints.json
@@ -80,7 +80,7 @@
 
   "GET /api/articles/:article_id/comments": {
     "description": "serves an array of comments for the specified article",
-    "queries": [],
+    "queries": ["limit", "p"],
     "exampleResponse": {
       "comments": [
         {

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,6 +1,6 @@
 const db = require("../db/connection");
 
-exports.fetchCommentsByArticle = (article_id) => {
+exports.fetchCommentsByArticle = (article_id, limit = 10) => {
   const queryStr = `
     SELECT 
       users.name AS author,
@@ -9,10 +9,11 @@ exports.fetchCommentsByArticle = (article_id) => {
       c.body 
     FROM comments AS c 
     JOIN users ON c.author = users.username 
-    WHERE article_id = $1;
+    WHERE article_id = $1
+    LIMIT $2;
   `;
 
-  const queryVals = [article_id];
+  const queryVals = [article_id, limit];
 
   return db.query(queryStr, queryVals).then((results) => {
     return results.rows;

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,6 +1,6 @@
 const db = require("../db/connection");
 
-exports.fetchCommentsByArticle = (article_id, limit = 10) => {
+exports.fetchCommentsByArticle = (article_id, limit = 10, p = 0) => {
   const queryStr = `
     SELECT 
       users.name AS author,
@@ -10,10 +10,10 @@ exports.fetchCommentsByArticle = (article_id, limit = 10) => {
     FROM comments AS c 
     JOIN users ON c.author = users.username 
     WHERE article_id = $1
-    LIMIT $2;
+    LIMIT $2 OFFSET $3;
   `;
 
-  const queryVals = [article_id, limit];
+  const queryVals = [article_id, limit, p * limit];
 
   return db.query(queryStr, queryVals).then((results) => {
     return results.rows;

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,5 +1,19 @@
 const db = require("../db/connection");
 
+exports.totalCommentsByArticle = (article_id) => {
+  const queryStr = `
+    SELECT
+      COUNT(*)::INT as total_count
+    FROM comments
+    WHERE article_id = $1;
+  `;
+
+  const queryVals = [article_id];
+  return db.query(queryStr, queryVals).then((results) => {
+    return results.rows[0];
+  });
+};
+
 exports.fetchCommentsByArticle = (article_id, limit = 10, p = 0) => {
   const queryStr = `
     SELECT 


### PR DESCRIPTION
Adds pagination to /api/articles/:article_id/comments via p and limit queries.Previous tests were refactored to account for new default values.

Tests:

* 200 returns 10 comments by default
* 200 returns specified number of comments
* 400 incorrect value for limit
* 200 specify a page (indexed from 0) to start at
* 200 limit and page calculated correctly
* 400 incorrect value for page
* 404 page does not exist